### PR TITLE
Add missing `Service` application layer — fix issue #4

### DIFF
--- a/src/Spryker/Zed/CodeGenerator/Business/CodeGeneratorBusinessFactory.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/CodeGeneratorBusinessFactory.php
@@ -16,6 +16,10 @@ use Spryker\Zed\CodeGenerator\Business\Generator\Client\ClientFactoryCodeGenerat
 use Spryker\Zed\CodeGenerator\Business\Generator\Client\ClientInterfaceCodeGenerator;
 use Spryker\Zed\CodeGenerator\Business\Generator\Client\Zed\StubCodeGenerator;
 use Spryker\Zed\CodeGenerator\Business\Generator\Client\Zed\StubInterfaceCodeGenerator;
+use Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceBundleCodeGenerator;
+use Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceCodeGenerator;
+use Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceFactoryCodeGenerator;
+use Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceInterfaceCodeGenerator;
 use Spryker\Zed\CodeGenerator\Business\Generator\Shared\SharedBundleCodeGenerator;
 use Spryker\Zed\CodeGenerator\Business\Generator\Shared\Transfer\TransferCodeGenerator;
 use Spryker\Zed\CodeGenerator\Business\Generator\Yves\Controller\YvesControllerCodeGenerator;
@@ -422,6 +426,7 @@ class CodeGeneratorBusinessFactory extends AbstractBusinessFactory
             $this->createZedBundleCodeGenerator($bundle),
             $this->createYvesBundleCodeGenerator($bundle),
             $this->createClientBundleCodeGenerator($bundle),
+            $this->createServiceBundleCodeGenerator($bundle),
             $this->createSharedBundleCodeGenerator($bundle),
         ];
     }
@@ -538,6 +543,19 @@ class CodeGeneratorBusinessFactory extends AbstractBusinessFactory
     /**
      * @param string $bundle
      *
+     * @return \Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceBundleCodeGenerator
+     */
+    public function createServiceBundleCodeGenerator($bundle)
+    {
+        return new ServiceBundleCodeGenerator(
+            $bundle,
+            $this->getRequiredServiceBundleCodeGenerators($bundle)
+        );
+    }
+
+    /**
+     * @param string $bundle
+     *
      * @return \Spryker\Zed\CodeGenerator\Business\Generator\Shared\SharedBundleCodeGenerator
      */
     public function createSharedBundleCodeGenerator($bundle)
@@ -570,6 +588,59 @@ class CodeGeneratorBusinessFactory extends AbstractBusinessFactory
     {
         return [
             $this->createTransferCodeGenerator($bundle),
+        ];
+    }
+
+    /**
+     * @param string $bundle
+     *
+     * @return \Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceCodeGenerator
+     */
+    public function createServiceCodeGenerator($bundle)
+    {
+        return new ServiceCodeGenerator(
+            $bundle,
+            $this->createTwigGeneratorEngine()
+        );
+    }
+
+    /**
+     * @param string $bundle
+     *
+     * @return \Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceInterfaceCodeGenerator
+     */
+    public function createServiceInterfaceCodeGenerator($bundle)
+    {
+        return new ServiceInterfaceCodeGenerator(
+            $bundle,
+            $this->createTwigGeneratorEngine()
+        );
+    }
+
+    /**
+     * @param string $bundle
+     *
+     * @return \Spryker\Zed\CodeGenerator\Business\Generator\Service\ServiceFactoryCodeGenerator
+     */
+    public function createServiceFactoryCodeGenerator($bundle)
+    {
+        return new ServiceFactoryCodeGenerator(
+            $bundle,
+            $this->createTwigGeneratorEngine()
+        );
+    }
+
+    /**
+     * @param string $bundle
+     *
+     * @return array
+     */
+    protected function getRequiredServiceBundleCodeGenerators($bundle)
+    {
+        return [
+            $this->createServiceCodeGenerator($bundle),
+            $this->createServiceInterfaceCodeGenerator($bundle),
+            $this->createServiceFactoryCodeGenerator($bundle),
         ];
     }
 

--- a/src/Spryker/Zed/CodeGenerator/Business/CodeGeneratorFacade.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/CodeGeneratorFacade.php
@@ -64,6 +64,20 @@ class CodeGeneratorFacade extends AbstractFacade
      *
      * @return \Generated\Shared\Transfer\CodeGeneratorResultTransfer[]
      */
+    public function generateServiceBundle($bundle)
+    {
+        return $this->getFactory()
+            ->createServiceBundleCodeGenerator($bundle)
+            ->generate();
+    }
+
+    /**
+     * @api
+     *
+     * @param string $bundle
+     *
+     * @return \Generated\Shared\Transfer\CodeGeneratorResultTransfer[]
+     */
     public function generateSharedBundle($bundle)
     {
         return $this->getFactory()

--- a/src/Spryker/Zed/CodeGenerator/Business/CodeGeneratorFacadeInterface.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/CodeGeneratorFacadeInterface.php
@@ -46,6 +46,15 @@ interface CodeGeneratorFacadeInterface
      *
      * @return \Generated\Shared\Transfer\CodeGeneratorResultTransfer[]
      */
+    public function generateServiceBundle($bundle);
+
+    /**
+     * @api
+     *
+     * @param string $bundle
+     *
+     * @return \Generated\Shared\Transfer\CodeGeneratorResultTransfer[]
+     */
     public function generateSharedBundle($bundle);
 
     /**

--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/AbstractServiceCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/AbstractServiceCodeGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\CodeGenerator\Business\Generator\Service;
+
+use Spryker\Zed\CodeGenerator\Business\Generator\AbstractPhpFileCodeGenerator;
+
+abstract class AbstractServiceCodeGenerator extends AbstractPhpFileCodeGenerator
+{
+
+    /**
+     * @return string
+     */
+    public function getPathToBundle()
+    {
+        return 'src';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getNamespace()
+    {
+        return sprintf(
+            'Pyz\Service\%s',
+            $this->getBundle()
+        );
+    }
+
+}

--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceBundleCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceBundleCodeGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\CodeGenerator\Business\Generator\Service;
+
+use Spryker\Zed\CodeGenerator\Business\Generator\AbstractCodeGenerator;
+
+class ServiceBundleCodeGenerator extends AbstractCodeGenerator
+{
+
+    /**
+     * @return string
+     */
+    public function getCodeGeneratorName()
+    {
+        return 'ServiceBundleCodeGenerator';
+    }
+
+}

--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceCodeGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\CodeGenerator\Business\Generator\Service;
+
+class ServiceCodeGenerator extends AbstractServiceCodeGenerator
+{
+
+    /**
+     * @return string
+     */
+    public function getSourceFile()
+    {
+        return 'Service/Service.php.twig';
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodeGeneratorName()
+    {
+        return 'Service';
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassname()
+    {
+        return sprintf(
+            '%sService',
+            $this->getBundle()
+        );
+    }
+
+}

--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceFactoryCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceFactoryCodeGenerator.php
@@ -32,7 +32,7 @@ class ServiceFactoryCodeGenerator extends AbstractServiceCodeGenerator
     public function getClassname()
     {
         return sprintf(
-            '%sFactory',
+            '%sServiceFactory',
             $this->getBundle()
         );
     }

--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceFactoryCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceFactoryCodeGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\CodeGenerator\Business\Generator\Service;
+
+class ServiceFactoryCodeGenerator extends AbstractServiceCodeGenerator
+{
+
+    /**
+     * @return string
+     */
+    public function getSourceFile()
+    {
+        return 'Service/Factory.php.twig';
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodeGeneratorName()
+    {
+        return 'ServiceFactory';
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassname()
+    {
+        return sprintf(
+            '%sFactory',
+            $this->getBundle()
+        );
+    }
+
+}

--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceInterfaceCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Service/ServiceInterfaceCodeGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\CodeGenerator\Business\Generator\Service;
+
+class ServiceInterfaceCodeGenerator extends AbstractServiceCodeGenerator
+{
+
+    /**
+     * @return string
+     */
+    public function getSourceFile()
+    {
+        return 'Service/ServiceInterface.php.twig';
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodeGeneratorName()
+    {
+        return 'ServiceInterface';
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassname()
+    {
+        return sprintf(
+            '%sServiceInterface',
+            $this->getBundle()
+        );
+    }
+
+}

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleServiceCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleServiceCodeGeneratorConsole.php
@@ -16,16 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @method \Spryker\Zed\CodeGenerator\Business\CodeGeneratorFacade getFacade()
  */
-class BundleCodeGeneratorConsole extends Console
+class BundleServiceCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:all';
-    const DESCRIPTION = 'Create a bundle (Zed, Service, Shared, Yves, and Client)';
+    const COMMAND_NAME = 'code:generate:bundle:service';
+    const DESCRIPTION = 'Generates Service for a bundle name';
 
     const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_DESCRIPTION_BUNDLE = 'Name of the bundle';
-
-    const OPTION_CORE = 'core';
+    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the bundle';
 
     /**
      * @return void
@@ -37,7 +35,7 @@ class BundleCodeGeneratorConsole extends Console
             ->addArgument(
                 self::ARGUMENT_BUNDLE,
                 InputArgument::REQUIRED,
-                self::ARGUMENT_DESCRIPTION_BUNDLE
+                self::ARGUMENT_BUNDLE_DESCRIPTION
             );
     }
 
@@ -52,7 +50,7 @@ class BundleCodeGeneratorConsole extends Console
         $bundle = $input->getArgument(self::ARGUMENT_BUNDLE);
 
         $codeGeneratorResultTransfers = $this->getFacade()
-            ->generateBundle($bundle);
+            ->generateServiceBundle($bundle);
 
         $messenger = $this->getMessenger();
 

--- a/templates/Service/Factory.php.twig
+++ b/templates/Service/Factory.php.twig
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use Spryker\Service\Kernel\AbstractServiceFactory;
+
+class {{ classname }} extends AbstractServiceFactory
+{
+
+    //TODO Add factory methods
+
+}

--- a/templates/Service/Service.php.twig
+++ b/templates/Service/Service.php.twig
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+use Spryker\Service\Kernel\AbstractService;
+
+/**
+ * @method \{{ namespace }}\{{ bundle }}ServiceFactory getFactory()
+ */
+class {{ classname }} extends AbstractService implements {{ classname }}Interface
+{
+
+    //TODO Add service methods
+
+}

--- a/templates/Service/ServiceInterface.php.twig
+++ b/templates/Service/ServiceInterface.php.twig
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+interface {{ classname }}
+{
+
+    //TODO Add service methods
+
+}


### PR DESCRIPTION
Enhance the generator for `Service` application layer.
```
code:generate:bundle:service
```
Also, `service` is added to `all` generator.