### PR TITLE
Fix Transfer name to the actual module name.

### DIFF
--- a/src/Spryker/Zed/CodeGenerator/Business/Generator/Shared/Transfer/TransferCodeGenerator.php
+++ b/src/Spryker/Zed/CodeGenerator/Business/Generator/Shared/Transfer/TransferCodeGenerator.php
@@ -13,6 +13,8 @@ use Zend\Filter\FilterChain;
 class TransferCodeGenerator extends AbstractSharedCodeGenerator
 {
 
+    const KEY_BUNDLE_CAMEL_BACKED = 'bundleCamelBacked';
+
     /**
      * @return string
      */
@@ -51,6 +53,17 @@ class TransferCodeGenerator extends AbstractSharedCodeGenerator
             'Transfer',
             $this->getClassname(),
         ]);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getVars()
+    {
+        $vars = parent::getVars();
+        $vars[static::KEY_BUNDLE_CAMEL_BACKED] = lcfirst($vars[static::KEY_BUNDLE]);
+
+        return $vars;
     }
 
     /**

--- a/templates/Shared/Transfer/transfer.xml
+++ b/templates/Shared/Transfer/transfer.xml
@@ -3,8 +3,8 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="spryker:transfer-01 http://static.spryker.com/transfer-01.xsd">
 
-    <transfer name="HelloWorld">
-        <property name="message" type="string"/>
+    <transfer name="{{ bundle }}">
+        <property name="{{ bundleCamelBacked }}" type="string"/>
     </transfer>
 
 </transfers>


### PR DESCRIPTION
Dynamic

        <transfer name="FooBar">

instead of always HelloWorld.