### PR TITLE
Rename bundle to module for console API as first step.

### DIFF
--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleClientCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleClientCodeGeneratorConsole.php
@@ -22,7 +22,7 @@ class BundleClientCodeGeneratorConsole extends Console
     const COMMAND_NAME = 'code:generate:module:client';
     const DESCRIPTION = 'Generates Client application layer for a module';
 
-    const ARGUMENT_BUNDLE = 'bundle';
+    const ARGUMENT_BUNDLE = 'module';
     const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleClientCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleClientCodeGeneratorConsole.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BundleClientCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:client';
-    const DESCRIPTION = 'Generates Client for a bundle name';
+    const COMMAND_NAME = 'code:generate:module:client';
+    const DESCRIPTION = 'Generates Client application layer for a module';
 
     const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the bundle (CamelCase)';
+    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**
      * @return void

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleCodeGeneratorConsole.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BundleCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:all';
-    const DESCRIPTION = 'Create a bundle (Zed, Service, Shared, Yves, and Client)';
+    const COMMAND_NAME = 'code:generate:module:all';
+    const DESCRIPTION = 'Create all application layers (Zed, Service, Shared, Yves, and Client) for a module';
 
-    const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_DESCRIPTION_BUNDLE = 'Name of the bundle';
+    const ARGUMENT_BUNDLE = 'module';
+    const ARGUMENT_DESCRIPTION_BUNDLE = 'Name of the module';
 
     const OPTION_CORE = 'core';
 

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleServiceCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleServiceCodeGeneratorConsole.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BundleServiceCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:service';
-    const DESCRIPTION = 'Generates Service for a bundle name';
+    const COMMAND_NAME = 'code:generate:module:service';
+    const DESCRIPTION = 'Generates Service application layer for a module';
 
-    const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the bundle';
+    const ARGUMENT_BUNDLE = 'module';
+    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**
      * @return void

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleSharedCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleSharedCodeGeneratorConsole.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BundleSharedCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:shared';
-    const DESCRIPTION = 'Generates Shared for a bundle name';
+    const COMMAND_NAME = 'code:generate:module:shared';
+    const DESCRIPTION = 'Generates Shared application layer for a module';
 
-    const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the bundle';
+    const ARGUMENT_BUNDLE = 'module';
+    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**
      * @return void

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleYvesCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleYvesCodeGeneratorConsole.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BundleYvesCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:yves';
-    const DESCRIPTION = 'Generates Yves for a bundle name';
+    const COMMAND_NAME = 'code:generate:module:yves';
+    const DESCRIPTION = 'Generates Yves application layer for a module';
 
     const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the bundle (CamelCase)';
+    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**
      * @return void

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleYvesCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleYvesCodeGeneratorConsole.php
@@ -22,7 +22,7 @@ class BundleYvesCodeGeneratorConsole extends Console
     const COMMAND_NAME = 'code:generate:module:yves';
     const DESCRIPTION = 'Generates Yves application layer for a module';
 
-    const ARGUMENT_BUNDLE = 'bundle';
+    const ARGUMENT_BUNDLE = 'module';
     const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleZedCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleZedCodeGeneratorConsole.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BundleZedCodeGeneratorConsole extends Console
 {
 
-    const COMMAND_NAME = 'code:generate:bundle:zed';
-    const DESCRIPTION = 'Generates Zed for a bundle name';
+    const COMMAND_NAME = 'code:generate:module:zed';
+    const DESCRIPTION = 'Generates Zed application layer for a module';
 
     const ARGUMENT_BUNDLE = 'bundle';
-    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the bundle (CamelCase)';
+    const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**
      * @return void

--- a/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleZedCodeGeneratorConsole.php
+++ b/src/Spryker/Zed/CodeGenerator/Communication/Console/BundleZedCodeGeneratorConsole.php
@@ -22,7 +22,7 @@ class BundleZedCodeGeneratorConsole extends Console
     const COMMAND_NAME = 'code:generate:module:zed';
     const DESCRIPTION = 'Generates Zed application layer for a module';
 
-    const ARGUMENT_BUNDLE = 'bundle';
+    const ARGUMENT_BUNDLE = 'module';
     const ARGUMENT_BUNDLE_DESCRIPTION = 'Name of the module';
 
     /**


### PR DESCRIPTION
First step: API only (no code changes yet) for the new module name.
Someone would need to also look into the code changes at some point, but that would be more a BC break then.

![selection_002](https://user-images.githubusercontent.com/39854/27337523-ec650a7e-55d2-11e7-976c-c031f738c287.png)