### PR TITLE
Fix code:generate:module:yves command

### DIFF
--- a/src/Spryker/Zed/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/Spryker/Zed/CodeGenerator/CodeGeneratorConfig.php
@@ -25,7 +25,7 @@ class CodeGeneratorConfig extends AbstractBundleConfig
     /**
      * @var string
      */
-    public const YVES_CONTROLLER_PROVIDER_CLASS = 'SprykerShop\Yves\ShopApplication\Plugin\Provider\AbstractYvesControllerProvider';
+    public const YVES_CONTROLLER_PROVIDER_CLASS = 'Spryker\Yves\Router\Plugin\RouteProvider\AbstractRouteProviderPlugin';
 
     /**
      * @api


### PR DESCRIPTION
## PR Description

The `AbstractYvesControllerProvider` class is deprecated and it was trying to load `Silex\ControllerProviderInterface` which does not exist in codebase anymore. So the `code:generate:module:yves` command was failing.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
